### PR TITLE
Fix Node.js engine version to satisfy @fastify/accept-negotiator requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {},
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",


### PR DESCRIPTION
### Description

This PR updates the **Node.js engine requirement** in the `package.json` file for the queue-service. The current configuration specifies `"node": ">=12"`, however the dependency **`@fastify/accept-negotiator`** requires **Node.js version 14 or higher**.

To ensure compatibility with this dependency and prevent potential build or runtime issues, the `engines.node` field has been updated to `"node": ">=14"`.

### Change Made

* Updated `package.json`

  * `engines.node` changed from `" >=12 "` → `" >=14 "`

### Impact

* Aligns the service with the minimum Node.js version required by Fastify dependencies.
* Prevents installation or runtime failures caused by unsupported Node versions.

No other functional changes were made.
